### PR TITLE
参加ロジックの実装

### DIFF
--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -74,4 +74,80 @@ router.get("/", async (_req, res) => {
   }
 })
 
+// イベント参加
+router.post("/:id/join", async (req, res) => {
+  try {
+    const eventId = req.params.id
+    const { userId } = req.body
+
+    if (!userId) {
+      return res.status(400).json({ error: "userId required" })
+    }
+
+    // ① イベント存在確認
+    const event = await prisma.event.findUnique({
+      where: { id: eventId },
+    })
+
+    if (!event) {
+      return res.status(404).json({ error: "Event not found" })
+    }
+
+    // ② 終了イベントチェック
+    if (new Date(event.endAt) <= new Date()) {
+      return res.status(400).json({ error: "Event already ended" })
+    }
+
+    // 🔥 ③ 既存レコード確認（ここが変更ポイント）
+    const existing = await prisma.participation.findFirst({
+      where: {
+        userId,
+        eventId,
+      },
+    })
+
+    // 🔥 ④ 分岐ロジック
+    if (existing) {
+      if (existing.status === "joined") {
+        return res.status(400).json({ error: "Already joined" })
+      }
+
+      // cancelled → 復活
+      const updated = await prisma.participation.update({
+        where: { id: existing.id },
+        data: { status: "joined" },
+      })
+
+      return res.json(updated)
+    }
+
+    // ⑤ 定員チェック
+    const currentCount = await prisma.participation.count({
+      where: {
+        eventId,
+        status: "joined",
+      },
+    })
+
+    if (currentCount >= event.capacity) {
+      return res.status(400).json({ error: "Event is full" })
+    }
+
+    // ⑥ 新規作成
+    const participation = await prisma.participation.create({
+      data: {
+        userId,
+        eventId,
+        status: "joined",
+      },
+    })
+
+    res.status(201).json(participation)
+
+  } catch (error) {
+    console.error(error)
+    res.status(500).json({ error: "Internal Server Error" })
+  }
+})
+
 export default router

--- a/backend/src/routes/participations.ts
+++ b/backend/src/routes/participations.ts
@@ -1,0 +1,41 @@
+import { Router } from "express"
+import prisma from "../prisma"
+
+const router = Router()
+
+// キャンセル
+router.patch("/:id/cancel", async (req, res) => {
+  try {
+    const participationId = req.params.id
+
+    // 🆕 ① 存在チェック
+    const participation = await prisma.participation.findUnique({
+      where: { id: participationId },
+    })
+
+    if (!participation) {
+      return res.status(404).json({ error: "Participation not found" })
+    }
+
+    // 🆕 ② すでにキャンセル済みチェック（任意）
+    if (participation.status === "cancelled") {
+      return res.status(400).json({ error: "Already cancelled" })
+    }
+
+    // ③ 更新
+    const updated = await prisma.participation.update({
+      where: { id: participationId },
+      data: {
+        status: "cancelled",
+      },
+    })
+
+    res.json(updated)
+
+  } catch (error) {
+    console.error(error)
+    res.status(500).json({ error: "Internal Server Error" })
+  }
+})
+
+export default router

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,7 @@ import dotenv from "dotenv"
 import prisma from "./prisma"
 import userRoutes from "./routes/users"
 import eventRoutes from "./routes/events"
+import participationRoutes from "./routes/participations"
 
 dotenv.config()
 
@@ -16,6 +17,7 @@ app.use(express.json())
 // ルーティング
 app.use("/users", userRoutes)
 app.use("/events", eventRoutes)
+app.use("/participations", participationRoutes)
 
 // ヘルスチェック
 app.get("/", (_req, res) => {


### PR DESCRIPTION
## ■ 概要

MVPにおける参加機能の中核ロジックを実装しました。

実装内容：

- ワンタップ参加API
- 定員制対応
- 重複参加防止
- 終了イベント参加防止
- キャンセル機能（論理削除）

MVPの参加フローがサーバー側で安全に制御できる状態になりました。

---

## ■ 実装内容

### 1️⃣ 参加API

### POST /events/:id/join

実装ロジック：

- イベント存在確認
- 終了イベントチェック（endAt > 現在日時）
- 重複参加チェック（status = joined）
- 定員チェック（status = joined のみカウント）
- 参加登録

---

### 2️⃣ キャンセルAPI

### PATCH /participations/:id/cancel

- status を "cancelled" に更新
- レコードは削除しない設計

---

### 3️⃣ 定員カウント仕様

- status = "joined" のみカウント対象
- cancelled はカウント除外

---

## ■ 動作確認項目

- [x] 正常に参加できる
- [x] 同一ユーザーの重複参加が防止される
- [x] 定員超過時に参加できない
- [x] 終了イベントに参加できない
- [x] キャンセルが正常に動作する
- [x] キャンセル後に再参加できる

---

## ■ 技術的判断

- 参加レコードは削除せず status 管理
- バリデーションはサーバー側で完結
- 同時アクセス対策（トランザクション）はMVP段階では未対応

---

## ■ 今後の予定

- フロント基盤構築
- 参加UI実装
- ローディング・エラーハンドリング改善
- 同時アクセス耐性向上（将来的課題）

---

## 関連issue
- close #4 

---

## ■ 備考

- 認証未実装のため userId はリクエストボディから受け取り
- JWT導入時に差し替え予定