### PR TITLE
イベント作成に「対象世代」の項目を追加

### DIFF
--- a/backend/prisma/migrations/20260328061837_remove_user_agegroup/migration.sql
+++ b/backend/prisma/migrations/20260328061837_remove_user_agegroup/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `ageGroup` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "ageGroup";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -13,7 +13,6 @@ model User {
   id             String           @id @default(uuid())
   name           String           @unique
   password       String
-  ageGroup       AgeGroup
   createdAt      DateTime         @default(now())
 
   events         Event[]          @relation("OrganizerEvents")

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -8,9 +8,9 @@ const router = Router()
 // サインアップ
 router.post("/signup", async (req, res) => {
   try {
-    const { name, password, ageGroup } = req.body
+    const { name, password } = req.body
 
-    if (!name || !password || !ageGroup) {
+    if (!name || !password) {
       return res.status(400).json({ error: "Missing fields" })
     }
 
@@ -28,7 +28,6 @@ router.post("/signup", async (req, res) => {
       data: {
         name,
         password: hashedPassword,
-        ageGroup,
       },
     })
 
@@ -66,7 +65,6 @@ router.post("/login", async (req, res) => {
       {
         userId: user.id,
         name: user.name,
-        ageGroup: user.ageGroup,
       },
       process.env.JWT_SECRET as string
     )
@@ -76,7 +74,6 @@ router.post("/login", async (req, res) => {
       user: {
         id: user.id,
         name: user.name,
-        ageGroup: user.ageGroup,
       },
     })
   } catch (error) {

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -15,8 +15,8 @@ router.post("/", authMiddleware, async (req: AuthRequest, res) => {
       location,
       capacity,
       allowSameDay,
-      organizerId,
       areaId,
+      targetGroups,
     } = req.body
 
     if (!title || !startAt || !endAt || !location || !capacity || !areaId) {
@@ -38,6 +38,13 @@ router.post("/", authMiddleware, async (req: AuthRequest, res) => {
         allowSameDay,
         organizerId: req.user!.userId,
         areaId,
+        targetGroups: targetGroups?.length
+          ? {
+              create: targetGroups.map((group: string) => ({
+                group,
+              })),
+            }
+          : undefined,
       },
     })
 
@@ -178,6 +185,7 @@ router.get("/:id", async (req, res) => {
         organizer: {
           select: { id: true, name: true },
         },
+        targetGroups: true,
       },
     })
 

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -205,7 +205,7 @@ router.get("/:id", async (req, res) => {
 router.put("/:id", authMiddleware, async (req: AuthRequest, res) => {
     try {
       const id = req.params.id as string
-      const { title, location, capacity, startAt, endAt, description } =
+      const { title, location, capacity, startAt, endAt, description, targetGroups } =
         req.body
 
       const event = await prisma.event.findUnique({ where: { id } })
@@ -229,6 +229,19 @@ router.put("/:id", authMiddleware, async (req: AuthRequest, res) => {
           description,
         },
       })
+
+      await prisma.eventTargetGroup.deleteMany({
+        where: { eventId: id },
+      })
+
+      if (targetGroups && targetGroups.length > 0) {
+        await prisma.eventTargetGroup.createMany({
+          data: targetGroups.map((group: string) => ({
+            eventId: id,
+            group,
+          })),
+        })
+      }
 
       res.json(updated)
     } catch (error) {

--- a/frontend/src/components/EventCard.tsx
+++ b/frontend/src/components/EventCard.tsx
@@ -18,6 +18,12 @@ type Props = {
   onDelete?: () => void
 }
 
+const AGE_LABELS: Record<string, string> = {
+  youth: "若者",
+  family: "家族",
+  senior: "高齢者",
+}
+
 const EventCard = ({
   event,
   isJoined,
@@ -76,6 +82,15 @@ const EventCard = ({
       {event.capacity && (
         <p style={{ margin: "4px 0", color: "#666" }}>
           👥 {event.currentJoinedCount} / {event.capacity}
+        </p>
+      )}
+
+      {(event.targetGroups?.length ?? 0) > 0 && (
+        <p>
+          👥 対象:{" "}
+          {(event.targetGroups ?? [])
+            .map((g: { group: string }) => AGE_LABELS[g.group] ?? g.group)
+            .join(" / ")}
         </p>
       )}
 

--- a/frontend/src/components/ui/TagSelector.tsx
+++ b/frontend/src/components/ui/TagSelector.tsx
@@ -1,0 +1,61 @@
+type Props = {
+  selected: string[]
+  onChange: (values: string[]) => void
+}
+
+const AGE_GROUPS = [
+  { label: "若者", value: "youth" },
+  { label: "家族", value: "family" },
+  { label: "高齢者", value: "senior" },
+]
+
+const TagSelector = ({ selected, onChange }: Props) => {
+  const toggle = (value: string) => {
+    if (selected.includes(value)) {
+      onChange(selected.filter((v) => v !== value))
+    } else {
+      onChange([...selected, value])
+    }
+  }
+
+  return (
+    <div style={{ marginTop: "20px", marginBottom: "20px" }}>
+      <p style={{ marginBottom: "10px", fontWeight: "bold", color: "#4CAF50", textAlign: "left" }}>
+        対象世代（任意）
+      </p>
+
+      <div style={{ display: "flex", gap: "10px", flexWrap: "wrap" }}>
+        {AGE_GROUPS.map((group) => {
+          const isSelected = selected.includes(group.value)
+
+          return (
+            <button
+              key={group.value}
+              type="button"
+              onClick={() => toggle(group.value)}
+              style={{
+                padding: "10px 16px",
+                borderRadius: "999px",
+                border: "none",
+                backgroundColor: isSelected ? "#4CAF50" : "#F5F5F5",
+                color: isSelected ? "#fff" : "#555",
+                fontSize: "14px",
+                fontWeight: "bold",
+                cursor: "pointer",
+                boxShadow: isSelected
+                  ? "0 2px 6px rgba(76, 175, 80, 0.4)"
+                  : "none",
+                transition: "0.2s",
+              }}
+            >
+              {isSelected ? "✓ " : ""}
+              {group.label}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default TagSelector

--- a/frontend/src/pages/CreateEvent.tsx
+++ b/frontend/src/pages/CreateEvent.tsx
@@ -3,12 +3,7 @@ import { useNavigate } from "react-router-dom"
 import client from "../api/client"
 import Input from "../components/ui/Input"
 import Button from "../components/ui/Button"
-
-const AGE_GROUPS = [
-  { label: "若者", value: "youth" },
-  { label: "家族", value: "family" },
-  { label: "高齢者", value: "senior" },
-]
+import TagSelector from "../components/ui/TagSelector"
 
 const CreateEvent = () => {
   const navigate = useNavigate()
@@ -22,14 +17,6 @@ const CreateEvent = () => {
   const [targetGroups, setTargetGroups] = useState<string[]>([])
 
   const AREA_ID = "eaeea7c2-011b-40ff-a872-2888628b5079"
-
-  const handleToggleGroup = (value: string) => {
-    setTargetGroups((prev) =>
-      prev.includes(value)
-        ? prev.filter((g) => g !== value)
-        : [...prev, value]
-    )
-  }
 
   const handleSubmit = async () => {
     if (!title || !location || !startAt || !endAt) {
@@ -69,23 +56,7 @@ const CreateEvent = () => {
       <Input value={endAt} onChange={(e) => setEndAt(e.target.value)} type="datetime-local" />
       <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="説明（任意）" />
 
-      <div style={{ marginTop: "16px" }}>
-        <p style={{ marginBottom: "8px" }}>対象世代（任意）</p>
-
-        {AGE_GROUPS.map((group) => (
-          <label
-            key={group.value}
-            style={{ display: "block", marginBottom: "4px" }}
-          >
-            <input
-              type="checkbox"
-              checked={targetGroups.includes(group.value)}
-              onChange={() => handleToggleGroup(group.value)}
-            />
-            {group.label}
-          </label>
-        ))}
-      </div>
+      <TagSelector selected={targetGroups} onChange={setTargetGroups} />
 
       <Button fullWidth onClick={handleSubmit}>作成</Button>
     </div>

--- a/frontend/src/pages/CreateEvent.tsx
+++ b/frontend/src/pages/CreateEvent.tsx
@@ -1,15 +1,16 @@
 import { useState } from "react"
 import { useNavigate } from "react-router-dom"
 import client from "../api/client"
-import type { User } from "../types/User"
 import Input from "../components/ui/Input"
 import Button from "../components/ui/Button"
 
-type Props = {
-  currentUser: User
-}
+const AGE_GROUPS = [
+  { label: "若者", value: "youth" },
+  { label: "家族", value: "family" },
+  { label: "高齢者", value: "senior" },
+]
 
-const CreateEvent = ({ currentUser }: Props) => {
+const CreateEvent = () => {
   const navigate = useNavigate()
 
   const [title, setTitle] = useState("")
@@ -17,8 +18,18 @@ const CreateEvent = ({ currentUser }: Props) => {
   const [capacity, setCapacity] = useState(1)
   const [startAt, setStartAt] = useState("")
   const [endAt, setEndAt] = useState("")
+  const [description, setDescription] = useState("")
+  const [targetGroups, setTargetGroups] = useState<string[]>([])
 
-  const AREA_ID = "e0d08572-bec7-442b-8e68-efa48711ea34"
+  const AREA_ID = "eaeea7c2-011b-40ff-a872-2888628b5079"
+
+  const handleToggleGroup = (value: string) => {
+    setTargetGroups((prev) =>
+      prev.includes(value)
+        ? prev.filter((g) => g !== value)
+        : [...prev, value]
+    )
+  }
 
   const handleSubmit = async () => {
     if (!title || !location || !startAt || !endAt) {
@@ -26,20 +37,26 @@ const CreateEvent = ({ currentUser }: Props) => {
       return
     }
 
-    await client.post("/events", {
-      title,
-      description: "",
-      startAt,
-      endAt,
-      location,
-      capacity,
-      allowSameDay: true,
-      organizerId: currentUser.id,
-      areaId: AREA_ID,
-    })
+    try {
+      await client.post("/events", {
+        title,
+        description,
+        startAt,
+        endAt,
+        location,
+        capacity,
+        allowSameDay: true,
+        areaId: AREA_ID,
+        targetGroups,
+      })
 
-    navigate("/")
+      navigate("/")
+    } catch (error) {
+      console.error(error)
+      alert("イベント作成に失敗しました")
+    }
   }
+
 
   return (
     <div>
@@ -50,6 +67,25 @@ const CreateEvent = ({ currentUser }: Props) => {
       <Input value={String(capacity)} onChange={(e) => setCapacity(Number(e.target.value))} type="number" />
       <Input value={startAt} onChange={(e) => setStartAt(e.target.value)} type="datetime-local" />
       <Input value={endAt} onChange={(e) => setEndAt(e.target.value)} type="datetime-local" />
+      <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="説明（任意）" />
+
+      <div style={{ marginTop: "16px" }}>
+        <p style={{ marginBottom: "8px" }}>対象世代（任意）</p>
+
+        {AGE_GROUPS.map((group) => (
+          <label
+            key={group.value}
+            style={{ display: "block", marginBottom: "4px" }}
+          >
+            <input
+              type="checkbox"
+              checked={targetGroups.includes(group.value)}
+              onChange={() => handleToggleGroup(group.value)}
+            />
+            {group.label}
+          </label>
+        ))}
+      </div>
 
       <Button fullWidth onClick={handleSubmit}>作成</Button>
     </div>

--- a/frontend/src/pages/EditEvent.tsx
+++ b/frontend/src/pages/EditEvent.tsx
@@ -1,15 +1,12 @@
 import { useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import client from "../api/client"
-import type { User } from "../types/User"
 import Input from "../components/ui/Input"
 import Button from "../components/ui/Button"
+import TagSelector from "../components/ui/TagSelector"
 
-type Props = {
-  currentUser: User
-}
 
-const EditEvent = ({ currentUser }: Props) => {
+const EditEvent = () => {
   const { id } = useParams()
   const navigate = useNavigate()
 
@@ -19,6 +16,7 @@ const EditEvent = ({ currentUser }: Props) => {
   const [startAt, setStartAt] = useState("")
   const [endAt, setEndAt] = useState("")
   const [description, setDescription] = useState("")
+  const [targetGroups, setTargetGroups] = useState<string[]>([])
 
   useEffect(() => {
     const fetchEvent = async () => {
@@ -33,6 +31,8 @@ const EditEvent = ({ currentUser }: Props) => {
       // datetime-local用変換
       setStartAt(event.startAt.slice(0, 16))
       setEndAt(event.endAt.slice(0, 16))
+
+      setTargetGroups(event.targetGroups?.map((g: any) => g.group) ?? [])
     }
 
     fetchEvent()
@@ -51,7 +51,7 @@ const EditEvent = ({ currentUser }: Props) => {
       startAt,
       endAt,
       description,
-      organizerId: currentUser.id,
+      targetGroups,
     })
 
     navigate(`/events/${id}`)
@@ -67,6 +67,8 @@ const EditEvent = ({ currentUser }: Props) => {
       <Input value={startAt} onChange={(e) => setStartAt(e.target.value)} type="datetime-local" />
       <Input value={endAt} onChange={(e) => setEndAt(e.target.value)} type="datetime-local" />
       <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="説明" />
+
+      <TagSelector selected={targetGroups} onChange={setTargetGroups} />
 
       <Button fullWidth onClick={handleSubmit}>
         更新

--- a/frontend/src/pages/EventDetail.tsx
+++ b/frontend/src/pages/EventDetail.tsx
@@ -84,6 +84,7 @@ const EventDetail = ({ currentUser }: Props) => {
 
           onDelete={handleDelete}
         />
+        
     </div>
   )
 }

--- a/frontend/src/pages/EventDetail.tsx
+++ b/frontend/src/pages/EventDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router-dom"
 import client from "../api/client"
 import EventCard from "../components/EventCard"
 import type { User } from "../types/User"
+import type { Event } from "../types/Event"
 
 type Props = {
   currentUser: User
@@ -12,7 +13,7 @@ const EventDetail = ({ currentUser }: Props) => {
   const { id } = useParams()
   const navigate = useNavigate()
 
-  const [event, setEvent] = useState<any>(null)
+  const [event, setEvent] = useState<Event | null>(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -84,7 +85,7 @@ const EventDetail = ({ currentUser }: Props) => {
 
           onDelete={handleDelete}
         />
-        
+
     </div>
   )
 }

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -6,7 +6,6 @@ import type { User } from "../types/User"
 import SimpleHeader from "../components/SimpleHeader"
 import PageContainer from "../components/ui/PageContainer"
 import Input from "../components/ui/Input"
-import Select from "../components/ui/Select"
 import Button from "../components/ui/Button"
 
 type Props = {
@@ -18,14 +17,12 @@ const Signup = ({ setCurrentUser }: Props) => {
 
   const [name, setName] = useState("")
   const [password, setPassword] = useState("")
-  const [ageGroup, setAgeGroup] = useState("youth")
 
   const handleSignup = async () => {
     try {
       await client.post("/auth/signup", {
         name,
         password,
-        ageGroup,
       })
 
       // 自動ログイン
@@ -52,12 +49,6 @@ const Signup = ({ setCurrentUser }: Props) => {
 
         <Input placeholder="名前" value={name} onChange={(e) => setName(e.target.value)} />
         <Input type="password" placeholder="パスワード" value={password} onChange={(e) => setPassword(e.target.value)} />
-
-        <Select value={ageGroup} onChange={(e) => setAgeGroup(e.target.value)} >
-          <option value="youth">若者</option>
-          <option value="family">家族</option>
-          <option value="senior">高齢者</option>
-        </Select>
 
         <Button fullWidth onClick={handleSignup}>登録</Button>
 

--- a/frontend/src/types/Event.ts
+++ b/frontend/src/types/Event.ts
@@ -8,4 +8,5 @@ export type Event = {
   description?: string
   allowSameDay: boolean
   currentJoinedCount: number
+  targetGroups?: {group: string}[]
 }

--- a/frontend/src/types/Event.ts
+++ b/frontend/src/types/Event.ts
@@ -8,5 +8,7 @@ export type Event = {
   description?: string
   allowSameDay: boolean
   currentJoinedCount: number
+  organizerId: string
+  participations: {id: string; userId: string}[]
   targetGroups?: {group: string}[]
 }


### PR DESCRIPTION
## Branch
feature/add-event-target-groups

---

## 概要

イベントに「対象世代（タグ）」を設定できる機能を追加しました。  
また、イベント作成・編集時にタグの追加・削除・更新ができるようにし、UIもタグ形式に改善しました。

---

## 対応内容

### ■ バックエンド

- Userモデルから `ageGroup` を削除
- EventTargetGroupを利用した対象世代管理に変更
- イベント更新時のタグ処理を修正
  - `deleteMany` + `createMany` による完全上書き方式に変更
- JWT・Signup処理からageGroup削除

---

### ■ フロントエンド

#### ▼ CreateEvent
- 対象世代タグ選択UIを追加
- checkbox → タグUIへ変更
- `targetGroups` をAPIに送信

#### ▼ EditEvent
- 対象世代の初期値を反映
- タグの追加・削除・全解除が可能
- 更新時に `targetGroups` を送信するよう修正

#### ▼ 共通
- `TagSelector` コンポーネント作成
- Create / Edit で共通利用
- UIの統一（スマホ対応含む）

---

### ■ UI改善

- タグ形式の選択UIに変更
- 選択状態の視認性向上（色・チェック）
- フォーム全体の余白・配置を調整
- ラベルの左寄せ統一

---

## 動作確認

### ① ユーザー作成

- [x] サインアップできる（ageGroup不要）
- [x] 自動ログインされる

---

### ② イベント作成

- [x] タグ選択できる（複数可）
- [x] タグ未選択でも作成できる
- [x] 作成後トップへ遷移

---

### ③ DB確認

- [x] Eventにデータが保存される
- [x] EventTargetGroupにタグが保存される

---

### ④ イベント詳細

- [x] タグが表示される
- [x] 未選択時は表示されない

---

### ⑤ 編集機能（最重要）

- [x] タグの初期値が表示される
- [x] タグを1つ削除できる
- [x] 全削除できる
- [x] タグ追加できる
- [x] 更新後、正しく反映される

---

### ⑥ ボタン挙動

- [x] カードクリックで詳細遷移
- [x] 参加ボタンで遷移しない
- [x] 編集・削除が正常動作

---

## 関連Issue

- close #18 

---

## 備考

- タグは「完全上書き方式」で更新しています（deleteMany → createMany）
- 将来的にタグ検索・フィルタ機能へ拡張予定